### PR TITLE
[SOFT-296] Stop fan control from failing after 8 1/3 hours

### DIFF
--- a/fan_control/fan_control.py
+++ b/fan_control/fan_control.py
@@ -43,9 +43,9 @@ def fan_control():
 
 def run():
     ''' Start, periodically call fan control '''
-    fan_control()
-    time.sleep(CHECK_DELAY_S)
-    run()
+    while True:
+        fan_control()
+        time.sleep(CHECK_DELAY_S)
 
 
 if(__name__ == "__main__"):


### PR DESCRIPTION
Python has a recursion limit of (by default) 1000 calls and doesn't do tail call elimination, so with a `CHECK_DELAY_S` of 30, using recursion for `run` would error out after 30*1000 = 30 000 s = 8 1/3 hours. To avoid centre console and the rPi suddenly overheating after 8 1/3 hours without a restart, let's just use iteration instead of recursion here.